### PR TITLE
Assign product.default_variant in product bulk create

### DIFF
--- a/saleor/graphql/product/bulk_mutations/product_bulk_create.py
+++ b/saleor/graphql/product/bulk_mutations/product_bulk_create.py
@@ -763,7 +763,7 @@ class ProductBulkCreate(BaseMutation):
                 )
 
             if variants_data := cleaned_input.pop("variants", None):
-                variants_input_data.extend(variants_data)
+                variants_input_data.append((product, variants_data))
 
         models.Product.objects.bulk_create(products_to_create)
         models.ProductMedia.objects.bulk_create(media_to_create)
@@ -772,8 +772,8 @@ class ProductBulkCreate(BaseMutation):
         for product, attributes in attributes_to_save:
             ProductAttributeAssignmentMixin.save(product, attributes)
 
-        if variants_input_data:
-            variants = cls.save_variants(info, variants_input_data)
+        for product, variants_to_create in variants_input_data:
+            variants.extend(cls.save_variants(info, variants_to_create, product))
 
         return variants, updated_channels
 
@@ -815,8 +815,10 @@ class ProductBulkCreate(BaseMutation):
         )
 
     @classmethod
-    def save_variants(cls, info, variants_input_data):
-        return ProductVariantBulkCreate.save_variants(info, variants_input_data, None)
+    def save_variants(cls, info, variants_input_data, product):
+        return ProductVariantBulkCreate.save_variants(
+            info, variants_input_data, product
+        )
 
     @classmethod
     def prepare_media(cls, info, product, media_inputs, media_to_create):


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separate repository: https://github.com/saleor/saleor-docs/. -->
<!-- Please provide a link to the PR that updates documentation for your changes. -->
<!-- If changes in docs are not required, please mention that in the description. -->

- [ ] Link to documentation:

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

- [ ] Privileged queries and mutations are either absent or guarded by proper permission checks
- [ ] Database queries are optimized and the number of queries is constant
- [ ] Database migrations are either absent or optimized for zero downtime
- [ ] The changes are covered by test cases
- [ ] All new fields/inputs/mutations have proper labels added (`ADDED_IN_X`, `PREVIEW_FEATURE`, etc.)
- [ ] All migrations have proper dependencies
- [ ] All indexes are added concurrently in migrations
- [ ] All RunSql and RunPython migrations have revert option defined
